### PR TITLE
Added --build_type flag

### DIFF
--- a/construct_cmake_project.py
+++ b/construct_cmake_project.py
@@ -145,7 +145,7 @@ def create_option_parser() -> ap.ArgumentParser:
 		default='debug',
 		required=False,
 		choices=['debug', 'release'],
-		help='Compile project with <debug|release> flag, Default: debug.\nIt will pass `-DCMAKE_BUILD_TYPE=<debug|releas>` in cmake command.'
+		help=f'Passes {Fore.YELLOW}release{Fore.RESET} or {Fore.YELLOW}debug{Fore.RESET} flag to {Fore.GREEN}CMakeLists.txt{Fore.RESET}, with {Fore.YELLOW}\'-DCMAKE_BUILD_TYPE=\'{Fore.RESET}.\nDefault: {Fore.YELLOW}debug{Fore.RESET}.'
 	)
 	
 	return parser

--- a/construct_cmake_project.py
+++ b/construct_cmake_project.py
@@ -55,7 +55,7 @@ def main() -> int:
 	print(f'>>> {Fore.GREEN}{os.getcwd()}{Fore.RESET}')
 	return 0
 
-def run_cmd(args: sp._CMD) -> sp.CompletedProcess:
+def run_cmd(args: sp) -> sp.CompletedProcess:
 	""" Equivalent to `subprocess.run(args, shell=True).check_returncode()`.
 	"""
 	res: sp.CompletedProcess = sp.run(args, shell=True)


### PR DESCRIPTION
Added `--build_type` flag with two possible options `<debug|release>`.
This passes to `-DCMAKE_BUILD_TYPE={buildType.capitalize()}` either of those option.
Which then can be used inside cmake script to apply proper optimizations/flags.

Indented 2 comments. Those annoyed me in editor as it folded up to those comments instead of whole function.

Removed `._CMD` part from `def run_cmd(args: sp)...` (line n. 58).
This returned following error:
```bash
$ python3 construct_project.py --help
Traceback (most recent call last):
  File "/home/caraczan/Documents/dev/cpp/pls/construct_project.py", line 58, in <module>
    def run_cmd(args: sp._CMD) -> sp.CompletedProcess:
                      ^^^^^^^
AttributeError: module 'subprocess' has no attribute '_CMD'
``` 
Without this part, script works fine. 